### PR TITLE
fix gulp clean task error

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -30,7 +30,7 @@ const path = {
 		img: 'src/img/**/*.*',
 		fonts: 'src/fonts/**/*.*'
 	},
-	clean: 'build/'
+	clean: './build/'
 };
 
 
@@ -98,7 +98,7 @@ const watcher = () => {
 };
 
 const cleanBuild = () => (
-	gulp.src(path.clean, {read: false})
+	gulp.src(path.clean, {allowEmpty: true})
 		.pipe(clean())
 );
 


### PR DESCRIPTION
Теперь галп не матерится, при отсутствии пустой папки `build` в проекте